### PR TITLE
Linux compiler fixes for Clang and GCC when using -Werror

### DIFF
--- a/UnitTests/rules.cpp
+++ b/UnitTests/rules.cpp
@@ -2223,7 +2223,7 @@ TEST( Rules, ProcessEventRules )
             SCOPED_TRACE( fieldValues.Description );
             PWCHAR ruleName = NULL;
             LARGE_INTEGER eventTime;
-            SYSMON_DATA_DESCRIPTOR eventBuffer[SYSMON_MAX_EVENT_Fields] = { (NativeTypes)0 };
+            SYSMON_DATA_DESCRIPTOR eventBuffer[SYSMON_MAX_EVENT_Fields] = {{(NativeTypes) 0}};
 
             // Set all fields in the event buffer, the rest won't be available.
             for( auto& field : fieldValues.Fields ) {

--- a/eventsCommon.cpp
+++ b/eventsCommon.cpp
@@ -510,7 +510,7 @@ void GenerateUniqueSGUID(
 	)
 {
 	GUID							g;
-	LARGE_INTEGER					timestamp = {0,};
+	LARGE_INTEGER					timestamp = {{0}};
 #if defined _WIN64 || defined _WIN32
 	NTSTATUS						status;
 	PSECURITY_LOGON_SESSION_DATA 	sessionData;
@@ -2114,7 +2114,7 @@ ProcessEventRulesDry(
 	)
 {
 	ULONG index;
-	EVENT_DATA_DESCRIPTOR output[SYSMON_MAX_EVENT_Fields] = {0,};
+	EVENT_DATA_DESCRIPTOR output[SYSMON_MAX_EVENT_Fields] = {{0}};
 	RuleDefaultType ret;
 
 	ret = ProcessEventRules( EventTime, EventType, EventBuffer, EventData, output, RuleName, NULL );
@@ -2172,12 +2172,12 @@ EventProcess(
 	RuleDefaultType				ruleDefault;
 	DWORD					error = ERROR_SUCCESS;
 	InTypes					outputType;
-	EVENT_DATA_DESCRIPTOR 	Output[SYSMON_MAX_EVENT_Fields] = {0,};
+	EVENT_DATA_DESCRIPTOR 	Output[SYSMON_MAX_EVENT_Fields] = {{0}};
     LARGE_INTEGER			currentTime;
 	PLARGE_INTEGER			eventTime = NULL;
 	PWCHAR					ruleName = NULL;
 #if defined _WIN64 || defined _WIN32
-	PTCHAR					OutStr[SYSMON_MAX_EVENT_Fields] = {0,};
+	PTCHAR					OutStr[SYSMON_MAX_EVENT_Fields] = {{0}};
 #elif defined __linux__
     size_t                  eventMax = 65536;
     char                    event[eventMax];
@@ -2666,7 +2666,7 @@ DWORD DispatchEvent(
 	PTCHAR							companyName, fileVersion, productName, fileDescription, originalFileName;
 	PTCHAR							id = NULL, message = NULL;
 	GUID							guid;
-	SYSMON_DATA_DESCRIPTOR			eventBuffer[SYSMON_MAX_EVENT_Fields] = {(NativeTypes) 0};
+	SYSMON_DATA_DESCRIPTOR			eventBuffer[SYSMON_MAX_EVENT_Fields] = {{(NativeTypes) 0}};
 	PSYSMON_PROCESS_ACCESS			processAccess;
 	PSYSMON_EVENT_TYPE_FMT			eventType;
 	PSYSMON_FILE_DELETE				fileDelete;
@@ -3244,7 +3244,7 @@ DWORD NetworkEvent(
 	_In_ const TCHAR* dstPortname
 )
 {
-	SYSMON_DATA_DESCRIPTOR		eventBuffer[SYSMON_MAX_EVENT_Fields] = {(NativeTypes) 0};
+	SYSMON_DATA_DESCRIPTOR		eventBuffer[SYSMON_MAX_EVENT_Fields] = {{(NativeTypes) 0}};
 
 	EventSetFieldX( eventBuffer, F_NC_UtcTime, N_LargeTime, *Time );
 	EventSetFieldX( eventBuffer, F_NC_ProcessGuid, N_ProcessId, OwnerPID );
@@ -3281,7 +3281,7 @@ DWORD SendStateEvent(
     _In_ PTCHAR FileVersion
     )
 {
-	SYSMON_DATA_DESCRIPTOR	eventBuffer[SYSMON_MAX_EVENT_Fields] = {(NativeTypes) 0};
+	SYSMON_DATA_DESCRIPTOR	eventBuffer[SYSMON_MAX_EVENT_Fields] = {{(NativeTypes) 0}};
 	TCHAR		schemaVersion[64];
 
 	_stprintf_s( schemaVersion, _countof(schemaVersion), _T("%.2f"), TO_DOUBLE( ConfigurationVersion ) );
@@ -3305,7 +3305,7 @@ DWORD SendConfigEvent(
 	_In_ PTCHAR ConfigHash
 	)
 {
-	SYSMON_DATA_DESCRIPTOR	eventBuffer[SYSMON_MAX_EVENT_Fields] = { (NativeTypes) 0 };
+	SYSMON_DATA_DESCRIPTOR	eventBuffer[SYSMON_MAX_EVENT_Fields] = {{(NativeTypes) 0}};
 
 	EventSetFieldS( eventBuffer, F_SCC_Configuration, ConfigPath, FALSE );
 	EventSetFieldS( eventBuffer, F_SCC_ConfigurationFileHash, ConfigHash ? ConfigHash : _T(""), FALSE );

--- a/xml.cpp
+++ b/xml.cpp
@@ -312,7 +312,7 @@ public:
 			// No entry so the blob is not set
 			//
 			D_ASSERT( blob == NULL );
-			RULE_REG_EXT baseRule = {0,};
+			RULE_REG_EXT baseRule = {{0}};
 
 			baseRule.header.Version = blobVersion;
 			baseRule.RuleRegSize = sizeof(baseRule);
@@ -1056,7 +1056,7 @@ ApplyConfigurationFile(
 	ULONG							version = 0;
 	PCONFIGURATION_OPTION_TYPE		option;
 	PSYSMON_EVENT_TYPE_FMT			rule = NULL;
-	ADD_RULES						addRules[10] = {0,};
+	ADD_RULES						addRules[10] = {{0}};
 	ULONG							aggregationId = 0;
 #if defined _WIN64 || defined _WIN32
 	char							fileName[MAX_PATH];

--- a/xml.cpp
+++ b/xml.cpp
@@ -353,7 +353,7 @@ public:
 
 	HRESULT UndoEventAdd()
 	{
-		if( lastEventOffset == 0 || prevLastEventOffset == ULONG_MAX ) {
+		if( lastEventOffset == 0 || (unsigned long)prevLastEventOffset == ULONG_MAX ) {
 
 			// Can't undo more than the very last event (no undo history).
 			return E_OUTOFMEMORY;


### PR DESCRIPTION
Most of the changes here are `{0,}` -> `{{0}}` cleanups similar to what's done in https://github.com/Sysinternals/SysmonForLinux/pull/36/commits/ea0aa159ead783f71c7abd38b61a5b1aeed871fd.

As well, there is one missing cast (converting a signed to unsigned int type). I *think* that this is fine, but someone else might want to double check the potential values of `prevLastEventOffset` in this context. It was being tested against `ULONG_MAX` which threw a warning when the types didn't match.